### PR TITLE
Stop using spread for passing arguments to component parent

### DIFF
--- a/src/components/Expand.js
+++ b/src/components/Expand.js
@@ -68,12 +68,12 @@ function renderLabelText(
 let counter = 0
 
 export default class Expand extends Component<ExpandProps, ExpandState> {
-  constructor() {
-    super(...arguments)
+  constructor(props: ExpandProps) {
+    super(props)
 
     // If consumer is managing expanded state, ie prop is set, then use that
     // for the initial internal state, otherwise start with component collapsed.
-    const expanded = this.props.expanded || false
+    const expanded = props.expanded || false
 
     this.state = {
       expanded,

--- a/src/components/Text.js
+++ b/src/components/Text.js
@@ -87,13 +87,13 @@ function getInputClassName(align?: ?ALIGN): string {
 }
 
 export default class Text extends Component<TextProps, TextState> {
-  constructor() {
-    super(...arguments)
+  constructor(props: TextProps) {
+    super(props)
 
     this.state = {
       animatingClearButtonOut: false,
       focused: false,
-      value: this.props.value,
+      value: props.value,
     }
   }
 

--- a/src/components/Textarea.js
+++ b/src/components/Textarea.js
@@ -79,13 +79,13 @@ function getInputClassName(align?: ?ALIGN): string {
 }
 
 export default class Textarea extends Component<TextareaProps, TextareaState> {
-  constructor() {
-    super(...arguments)
+  constructor(props: TextareaProps) {
+    super(props)
 
     this.state = {
       animatingClearButtonOut: false,
       focused: false,
-      value: this.props.value,
+      value: props.value,
     }
   }
 


### PR DESCRIPTION
### This project uses [semver](semver.org), please check the scope of this pr:

*   [x] #none# - documentation fixes and/or test additions
*   [ ] #patch# - backwards-compatible bug fix
*   [ ] #minor# - adding functionality in a backwards-compatible manner
*   [ ] #major# - incompatible API change

# CHANGELOG

*   Changing code to not use argument spread for passing props to parent components.
